### PR TITLE
release 0.4.0

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -7,6 +7,7 @@ root: true
 
 parserOptions:
   ecmaVersion: 2020
+  sourceType: module
 
 extends:
   - eslint:recommended

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -27,10 +27,10 @@ jobs:
     - name: npm install
       run: |
         npm install
-        npm install --no-save nyc codecov
+        npm install --no-save c8 codecov
 
     - name: run coverage
-      run: npx nyc --reporter=lcovonly npm run test
+      run: npx c8 --reporter=lcovonly npm run test
       env:
         NODE_ENV: cov
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,18 +22,16 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node.js ${{ env.node_version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           registry-url: https://registry.npmjs.org/
 
       - run: npm install
 
-      - name: Run tests
-        run: npm run test
+      - run: npm run test
 
-      - name: publish to NPM
-        run: npm publish --access public
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.4.0](https://github.com/NicTool/dns-nameserver/compare/v0.1.0...v0.4.0) (2022-04-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* convert from CJS to ESM
+
+### Features
+
+* add maradns config parser ([#5](https://github.com/NicTool/dns-nameserver/issues/5)) ([4496497](https://github.com/NicTool/dns-nameserver/commit/449649784901ed02a3753a1b85f25d5617566492))
+* parsers added for Knot ([#2](https://github.com/NicTool/dns-nameserver/issues/2)) ([139235e](https://github.com/NicTool/dns-nameserver/commit/139235e8acd105ce872cddb22224e1470c972cbe))
+
+
+* convert from CJS to ESM ([11b66b2](https://github.com/NicTool/dns-nameserver/commit/11b66b2b83416fdb3338f9d537c9643814a13960))
+
 ## [0.3.0](https://github.com/NicTool/dns-nameserver/compare/v0.1.0...v0.3.0) (2022-04-09)
 
 

--- a/bin/nt-ns.js
+++ b/bin/nt-ns.js
@@ -1,0 +1,111 @@
+#!node
+
+// import fs from 'node:fs/promises'
+// const path = require('path')
+// const os   = require('os')
+
+// eslint-disable-next-line node/shebang
+import chalk from 'chalk'
+
+import cmdLineArgs from 'command-line-args'
+import cmdLineUsage from 'command-line-usage'
+
+function usage () {
+  console.error(cmdLineUsage(usageSections()))
+  // eslint-disable-next-line no-process-exit
+  process.exit(1)
+}
+
+// CLI argument processing
+const opts = cmdLineArgs(usageOptions())._all
+if (opts.verbose) console.error(opts)
+if (opts.help) usage()
+
+
+function usageOptions () {
+  return [
+    {
+      name        : 'import',
+      alias       : 'i',
+      defaultValue: 'bind',
+      type        : String,
+      typeLabel   : '<bind | knot | maradns | nsd | tinydns>',
+      description : 'nameserver type',
+      group       : 'io',
+    },
+    {
+      name        : 'export',
+      alias       : 'e',
+      defaultValue: 'js',
+      type        : String,
+      typeLabel   : '<bind | knot | maradns | nsd>',
+      description : 'nameserver type',
+      group       : 'io',
+    },
+    {
+      name        : 'file',
+      alias       : 'f',
+      // defaultValue: '',
+      type        : String,
+      typeLabel   : '<file path>',
+      description : 'source of DNS server config file',
+      group       : 'io',
+    },
+    {
+      name       : 'verbose',
+      alias      : 'v',
+      description: 'Show status messages during processing',
+      type       : Boolean,
+    },
+    {
+      name       : 'help',
+      description: 'Display this usage guide',
+      alias      : 'h',
+      type       : Boolean,
+    },
+  ]
+}
+
+function usageSections () {
+  return [
+    {
+      content: chalk.blue(` +-+-+-+ +-+-+-+-+-+-+-+-+-+-+\n |D|N|S| |N|A|M|E|S|E|R|V|E|R|\n +-+-+-+ +-+-+-+-+-+-+-+-+-+-+`),
+      raw    : true,
+    },
+    {
+      header    : 'I/O',
+      optionList: usageOptions(),
+      group     : 'io',
+    },
+    {
+      header    : 'NS Settings',
+      optionList: usageOptions(),
+      group     : 'main',
+    },
+    {
+      header    : 'Misc',
+      optionList: usageOptions(),
+      group     : '_none',
+    },
+    {
+      header : 'Examples',
+      content: [
+        {
+          desc   : '1. ',
+          example: './bin/nt-ns.js ',
+        },
+        {
+          desc   : '2. ',
+          example: './bin/nt-ns.js ',
+        },
+        {
+          desc   : '3. ',
+          example: './bin/nt-ns.js ',
+        },
+      ],
+    },
+    {
+      content: 'Project home: {underline https://github.com/NicTool/dns-nameserver}',
+    },
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -4,18 +4,10 @@
 
 
 
+export function valueCleanup (str) {
 
-
-
-
-
-
-
-
-exports.valueCleanup = function (str) {
-  // strip double quotes
-  if (str.charAt(0) === '"' && str.charAt(str.length -1) === '"') {
-    str = str.substr(1,str.length -2)
+  if (str.startsWith('"') && str.endsWith('"')) {
+    str = str.substr(1,str.length -2) // strip double quotes
   }
 
   if (/^[0-9.]+$/.test(str) && Number(str).toString() === str) {
@@ -24,3 +16,4 @@ exports.valueCleanup = function (str) {
 
   return str
 }
+

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -1,25 +1,98 @@
+// https://bind9.readthedocs.io/en/latest/reference.html
 
+import { valueCleanup } from '../index.js'
+
+
+export function parseConfig (str) {
+
+  const re = {
+    open    : /^\s*([\w\t -]+?)\s*{\s*$/,  // logging, options, etc.
+    openzone: /^\s*zone\s*"([^"]+)"\s*(in|IN)?{/,
+    close   : /^\s*(};)\s*$/,
+    key_val : /^[ \t]+([^\s]+?)\s+([^\r\n]+?)\s*(\/\/[^\r\n]+)?$/,
+    keyOnly : /^[ \t]+([^\s]+?)\s*;$/,
+    blank   : /^\s*?$/,
+    comment : /^\s*(?:\/\/)[^\r\n]*?$/,
+  }
+
+  const res = {}
+  const statement = []
+  let inner = {}
+
+  for (const line of str.split(/[\r\n]/)) {
+    if (re.blank.test(line)) continue
+    if (re.comment.test(line)) continue
+
+    const open = line.match(re.open)
+    if (open) {
+      statement.push(open[1])
+      continue
+    }
+
+    const openzone = line.match(re.openzone)
+    if (openzone) {
+      statement.push('zone')
+      inner.name = openzone[1]
+      continue
+    }
+
+    const close = line.match(re.close)
+    if (close) {
+      const statementName = statement.pop()
+
+      if (statementName === 'zone') {
+        if (res.zone === undefined) res.zone = []
+        res.zone.push(inner)
+        inner = {}
+      }
+      else {
+        let target = res
+        for (const s of statement) {
+          if (target[s] === undefined) target[s] = {}
+          target = target[s]
+        }
+        if (Object.keys(inner).length) {
+          target[statementName] = inner
+        }
+      }
+
+      inner = {}
+      continue
+    }
+
+    const kv = line.match(re.key_val)
+    const ko = line.match(re.keyOnly)
+
+    if (kv) {
+      inner[kv[1]] = valueCleanup(kv[2].slice(0,-1))
+    }
+    else if (ko) {
+      inner[ko[1]] = ''
+    }
+    else {
+      console.error(line)
+      throw 'parser failed'
+    }
+  }
+
+  return res
+}
+
+
+
+/*
 const os = require('os')
-
 const nearley = require('nearley')
-
 exports.parseConfig = async str => {
-
-  // eslint-disable-next-line node/no-unpublished-require
   const grammar = nearley.Grammar.fromCompiled(require('../dist/bind.js'))
   grammar.start = 'main'
-
   const parser = new nearley.Parser(grammar)
   parser.feed(str)
   if (!str.endsWith(os.EOL)) parser.feed(os.EOL)
-
-  if (parser.length > 1) {
-    console.error(`ERROR: ambigious parser rule`)
-  }
-
+  if (parser.length > 1) console.error(`ERROR: ambigious parser rule`)
   if (parser.results.length === 0) return []
-
   return parser.results[0]
     .filter(z => z[0] && z[0].type) // weed out nulls
     .map(z => z[0])   // remove array nesting
 }
+*/

--- a/lib/knot.js
+++ b/lib/knot.js
@@ -1,34 +1,93 @@
 
+
+import { valueCleanup } from '../index.js'
+
+
+export function parseConfig (str) {
+
+  const re = {
+    // fixed "top" level sections
+    topOpen: /^(acl|control|database|key|keystore|module|policy|remote|server|submission|template|zone|log):\s*?$/,
+    key_val: /^[ \t]+([^\s]+?):\s*([^\r\n#]+?)\s*(#[^\r\n]+)?$/,
+    arrItem: /^[ \t]+-\s+([^\s]+?):\s*([^\r\n#]+?)\s*(#[^\r\n]+)?$/,
+    // array  : /^[ \t]+\s+\[[^\]]\]\s*$/,
+    blank  : /^\s*?$/,
+    comment: /^\s*(?:#)[^\r\n]*?$/,
+  }
+
+  const res = {}
+  let section = ''
+  let inner = {}
+
+  function storeAccumulatedSection () {
+    if (res[section] === undefined) res[section] = []
+    if (Object.keys(inner).length) res[section].push(inner)
+    inner = {}
+  }
+
+  for (const line of str.split(/[\r\n]/)) {
+    if (re.blank.test(line)) continue
+    if (re.comment.test(line)) continue
+
+    const topOpen = line.match(re.topOpen)
+    if (topOpen) {
+      if (section) storeAccumulatedSection()
+      section = topOpen[1]
+      continue
+    }
+
+    const itemOpen = line.match(re.arrItem)
+    if (itemOpen) {
+      if (Object.keys(inner).length) storeAccumulatedSection()
+
+      inner[itemOpen[1]] = valueCleanup(itemOpen[2])
+      continue
+    }
+
+    const setting = line.match(re.key_val)
+    if (setting) {
+      // array items can be multiple of identical key
+      if ([ 'listen', 'address', 'via' ].includes(setting[1])) {
+        if (inner[setting[1]] === undefined) inner[setting[1]] = []
+        inner[setting[1]].push(valueCleanup(setting[2]))
+      }
+      else {
+        inner[setting[1]] = valueCleanup(setting[2])
+      }
+    }
+    else {
+      console.log(line)
+      throw ('parser failed')
+    }
+  }
+
+  if (section) {
+    if (res[section] === undefined) res[section] = []
+    res[section].push(inner)
+  }
+
+  return res
+}
+
+
+
+/*
 const os = require('os')
-
 const nearley = require('nearley')
-
 exports.parseConfig = async str => {
-
-  // eslint-disable-next-line node/no-unpublished-require
   const grammar = nearley.Grammar.fromCompiled(require('../dist/knot.js'))
   grammar.start = 'main'
-
   const parser = new nearley.Parser(grammar)
   parser.feed(str)
   if (!str.endsWith(os.EOL)) parser.feed(os.EOL)
-
   if (parser.results.length === 0) return []
-
   const r = {}
-
   const sections = [ 'acl', 'key', 'log', 'policy', 'remote', 'server', 'template', 'zone' ]
-
   parser.results[0][0]
     .filter(z => z !== null)
-    .map(z => {
-      for (const s of sections) {
-        if (z[s]) {
-          if (!r[s]) r[s] = []
-          r[s].push(...z[s])
-        }
-      }
-    })
-
+    .map(z => { for (const s of sections) {
+      if (z[s]) { if (!r[s]) r[s] = [] r[s].push(...z[s]) }
+    }})
   return r
 }
+*/

--- a/lib/maradns.js
+++ b/lib/maradns.js
@@ -1,7 +1,8 @@
 
-const ns = require('../index')
+import { valueCleanup } from '../index.js'
 
-exports.parseConfig = async str => {
+
+export function parseConfig (str) {
   // https://maradns.samiam.org/tutorial/man.mararc.html
 
   const re = {
@@ -19,7 +20,7 @@ exports.parseConfig = async str => {
 
     const match = line.match(re.variable)
     if (match) {
-      res[match[1]] = ns.valueCleanup(match[2])
+      res[match[1]] = valueCleanup(match[2])
     }
     else {
       console.log(line)
@@ -29,3 +30,4 @@ exports.parseConfig = async str => {
 
   return res
 }
+

--- a/lib/nsd.js
+++ b/lib/nsd.js
@@ -1,36 +1,74 @@
 
+import { valueCleanup } from '../index.js'
+
+
+export function parseConfig (str) {
+
+  const re = {
+    top    : /^(key|pattern|remote-control|server|tls-auth|zone):\s*?$/,
+    key_val: /^[ \t]+([^\s]+?):\s*([^\r\n#]+?)\s*(#[^\r\n]+)?$/,
+    blank  : /^\s*?$/,
+    comment: /^\s*(?:#)[^\r\n]*?$/,
+  }
+
+  const res = {}
+  let topBlock = ''
+  let inner = {}
+
+  for (const line of str.split(/[\r\n]/)) {
+    if (re.blank.test(line)) continue
+    if (re.comment.test(line)) continue
+
+    const top = line.match(re.top)
+    if (top) {
+      if (topBlock) {
+        // store the collected attributes with the top block
+        if (res[topBlock] === undefined) res[topBlock] = []
+        res[topBlock].push(inner)
+        inner = {}
+      }
+      topBlock = top[1]
+      continue
+    }
+
+    const match = line.match(re.key_val)
+    if (match) {
+      inner[match[1]] = valueCleanup(match[2])
+    }
+    else {
+      console.log(line)
+      throw ('parser failed')
+    }
+  }
+
+  if (topBlock) {
+    if (res[topBlock] === undefined) res[topBlock] = []
+    res[topBlock].push(inner)
+  }
+
+  return res
+}
+
+
+/*
 const os = require('os')
-
 const nearley = require('nearley')
-
 const ns = require('../index')
-
 exports.parseConfig = async str => {
-
-  // eslint-disable-next-line node/no-unpublished-require
   const grammar = nearley.Grammar.fromCompiled(require('../dist/nsd.js'))
   grammar.start = 'main'
-
   const parser = new nearley.Parser(grammar)
   parser.feed(str + os.EOL)
   if (!str.endsWith(os.EOL)) parser.feed(os.EOL)
-
   if (parser.results.length === 0) return []
-
   const r = {}
-
   const sections = [ 'key', 'pattern', 'remote-control', 'server', 'tls-auth', 'zone' ]
-
   parser.results[0]
     .filter(z => z !== null)
-    .map(z => {
-      for (const s of sections) {
-        if (z[s]) {
-          if (!r[s]) r[s] = []
-          r[s].push(z[s])
-        }
-      }
-    })
+    .map(z => { for (const s of sections) {
+      if (z[s]) { if (!r[s]) r[s] = []; r[s].push(z[s]) }
+    }})
 
   return r
 }
+*/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "DNS Nameserver",
   "main": "index.js",
   "bin": {},
+  "type": "module",
   "engines": {
     "node": ">=14.0"
   },
@@ -42,6 +43,9 @@
     "standard-version": "^9.3.2"
   },
   "dependencies": {
+    "chalk": "^5.0.1",
+    "command-line-args": "^5.2.1",
+    "command-line-usage": "^6.1.2",
     "nearley": "^2.20.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dns-nameserver",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "DNS Nameserver",
   "main": "index.js",
   "bin": {},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "grammar": "npm run bind && npm run knot && npm run nsd",
     "lint": "npx eslint index.js test/*.js",
     "lintfix": "npx eslint --fix index.js test/*.js",
-    "postinstall": "npm run grammar",
     "release": "npx standard-version --release-as=minor",
     "test": "npx mocha",
     "versions": "npx dependency-version-checker check"
@@ -45,7 +44,6 @@
   "dependencies": {
     "chalk": "^5.0.1",
     "command-line-args": "^5.2.1",
-    "command-line-usage": "^6.1.2",
-    "nearley": "^2.20.1"
+    "command-line-usage": "^6.1.2"
   }
 }

--- a/test/bind.js
+++ b/test/bind.js
@@ -1,8 +1,8 @@
 
-const assert = require('assert')
-const fs     = require('fs').promises
+import assert from 'assert'
+import fs     from 'fs/promises'
 
-const ns = require('../lib/bind.js')
+import { parseConfig } from '../lib/bind.js'
 
 
 describe('bind', function () {
@@ -13,9 +13,52 @@ describe('bind', function () {
       const file = './test/fixtures/bind/named.conf-ztrax-master'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
-      assert.equal(r.length, 5)
+      assert.deepStrictEqual(r, {
+        options: {
+          directory        : '/var/named',
+          version          : 'get lost',
+          'allow-transfer' : '{"none";}',
+          'allow-recursion': '{192.168.3.0/24;}',
+        },
+        logging: {
+          'channel example_log': {
+            file            : '"/var/log/named/example.log" versions 3 size 2m',
+            severity        : 'info',
+            'print-severity': 'yes',
+            'print-time'    : 'yes',
+            'print-category': 'yes',
+          },
+          'category default': { example_log: '' },
+        },
+        zone: [
+          { name: '.', type: 'hint', file: 'root.servers' },
+          {
+            name            : 'example.com',
+            type            : 'master',
+            file            : 'master/master.example.com',
+            'allow-transfer': '{192.168.23.1;192.168.23.2;}',
+          },
+          {
+            name                 : 'localhost',
+            type                 : 'master',
+            file                 : 'master.localhost',
+            'allow-update{none;}': '',
+          },
+          {
+            name                 : '0.0.127.in-addr.arpa',
+            type                 : 'master',
+            file                 : 'localhost.rev',
+            'allow-update{none;}': '',
+          },
+          {
+            name: '0.168.192.IN-ADDR.ARPA',
+            type: 'master',
+            file: '192.168.0.rev',
+          },
+        ],
+      })
     })
   })
 

--- a/test/knot.js
+++ b/test/knot.js
@@ -1,8 +1,9 @@
 
-const assert = require('assert')
-const fs     = require('fs').promises
+import assert from 'assert'
+import fs     from 'fs/promises'
 
-const ns = require('../lib/knot.js')
+import { parseConfig } from '../lib/knot.js'
+
 
 describe('knot', function () {
 
@@ -12,10 +13,10 @@ describe('knot', function () {
       const file = './test/fixtures/knot/knotd-v2.conf'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepEqual(r, {
-        server: [{ listen: '0.0.0.0@53' }, { listen: '::@53' }],
+        server: [{ listen: [ '0.0.0.0@53', '::@53' ] }],
         zone  : [
           {
             domain : 'example.com',
@@ -31,10 +32,10 @@ describe('knot', function () {
       const file = './test/fixtures/knot/knotd-v3.conf'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepEqual(r, {
-        server: [{ listen: '0.0.0.0@53' }, { listen: '::@53' }],
+        server: [{ listen: [ '0.0.0.0@53' ,'::@53' ] }],
         zone  : [
           {
             domain : 'example.com',
@@ -50,10 +51,10 @@ describe('knot', function () {
       const file = './test/fixtures/knot/knot-flex.conf'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepStrictEqual(r, {
-        server: [{ listen: '0.0.0.0@53' }, { listen: '::@53' }],
+        server: [{ listen: [ '0.0.0.0@53', '::@53' ] }],
         zone  : [
           {
             domain : 'example.com',
@@ -76,7 +77,7 @@ describe('knot', function () {
       const file = './test/fixtures/knot/ns2.cadillac.net.conf'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepEqual(r, {
         zone: [

--- a/test/maradns.js
+++ b/test/maradns.js
@@ -1,8 +1,8 @@
 
-const assert = require('assert')
-const fs     = require('fs').promises
+import assert from 'assert'
+import fs     from 'fs/promises'
 
-const ns = require('../lib/maradns.js')
+import { parseConfig } from '../lib/maradns.js'
 
 describe('maradns', function () {
 
@@ -12,7 +12,7 @@ describe('maradns', function () {
       const file = './test/fixtures/maradns/mararc'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepEqual(r, {
         chroot_dir         : '/etc/maradns',
@@ -31,7 +31,7 @@ describe('maradns', function () {
       const file = './test/fixtures/maradns/example.com'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepEqual(r, {
         'csv2["example.com."]' : 'db.example.com',

--- a/test/nsd.js
+++ b/test/nsd.js
@@ -1,8 +1,8 @@
 
-const assert = require('assert')
-const fs     = require('fs').promises
+import assert from 'assert'
+import fs     from 'fs/promises'
 
-const ns = require('../lib/nsd.js')
+import { parseConfig } from '../lib/nsd.js'
 
 
 describe('nsd', function () {
@@ -13,12 +13,12 @@ describe('nsd', function () {
       const file = './test/fixtures/nsd/nsd.conf'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepEqual(r, {
         server: [
           {
-            'server-count': '1',
+            'server-count': 1,
             database      : '',
             zonelistfile  : '/var/db/nsd/zone.list',
             username      : 'nsd',
@@ -49,16 +49,26 @@ describe('nsd', function () {
       const file = './test/fixtures/nsd/example.com'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepEqual(r, {
         server: [
           {
-            'server-count': '1',
+            'server-count': 1,
             database      : '',
             logfile       : '/var/log/nsd.log',
             pidfile       : '/var/run/nsd.pid',
             username      : 'nsd',
+          },
+        ],
+        'remote-control': [
+          {
+            'control-cert-file': '/etc/nsd/nsd_control.pem',
+            'control-enable'   : 'yes',
+            'control-interface': '127.0.0.1',
+            'control-key-file' : '/etc/nsd/nsd_control.key',
+            'server-cert-file' : '/etc/nsd/nsd_server.pem',
+            'server-key-file'  : '/etc/nsd/nsd_server.key',
           },
         ],
         zone: [
@@ -74,7 +84,7 @@ describe('nsd', function () {
       const file = './test/fixtures/nsd/ns2.cadillac.net.conf'
       const buf = await fs.readFile(file)
 
-      const r = await ns.parseConfig(buf.toString())
+      const r = await parseConfig(buf.toString())
       // console.dir(r, { depth: null })
       assert.deepEqual(r, {
         zone: [


### PR DESCRIPTION
- style: convert from CJS to ESM
- reimplement parsers in pure JS (bye nearley & moo)
- nsd: add value cleanups
- knot: handle array-type items
- test(bind): greatly improved test
- feat: start on nt-ns.js